### PR TITLE
Updated vehicle edit form to include rules checkbox

### DIFF
--- a/vehicles/forms.py
+++ b/vehicles/forms.py
@@ -124,7 +124,7 @@ E.g. how you *know* a vehicle has *definitely been* withdrawn or repainted,
 link to a picture to prove it. Be polite.""",
     )
     rules = forms.BooleanField(
-        label="I agree that my edit is made in good faith and complies with the "<a href="/rules">editing rules</a>"
+        label="I agree that my edit is made in good faith and complies with the "<a href="/rules">editing rules</a>
         required=true,
     )
 

--- a/vehicles/forms.py
+++ b/vehicles/forms.py
@@ -125,7 +125,7 @@ link to a picture to prove it. Be polite.""",
     )
     rules = forms.BooleanField(
         label="I agree that my edit is made in good faith and complies with the <a href=\"/rules\">editing rules</a>",
-        required=true,
+        required=True,
     )
 
     def clean_reg(self):

--- a/vehicles/forms.py
+++ b/vehicles/forms.py
@@ -124,7 +124,7 @@ E.g. how you *know* a vehicle has *definitely been* withdrawn or repainted,
 link to a picture to prove it. Be polite.""",
     )
     rules = forms.BooleanField(
-        label="I agree that my edit is made in good faith and complies with the <a href=\"/rules\ ">editing rules</a>",
+        label="I agree that my edit is made in good faith and complies with the <a href=\"/rules\">editing rules</a>",
         required=true,
     )
 

--- a/vehicles/forms.py
+++ b/vehicles/forms.py
@@ -124,7 +124,7 @@ E.g. how you *know* a vehicle has *definitely been* withdrawn or repainted,
 link to a picture to prove it. Be polite.""",
     )
     rules = forms.BooleanField(
-        label="I agree that my edit is made in good faith and complies with the "<a href="/rules">editing rules</a>
+        label="I agree that my edit is made in good faith and complies with the "<a href="/rules">editing rules</a>,
         required=true,
     )
 

--- a/vehicles/forms.py
+++ b/vehicles/forms.py
@@ -124,7 +124,7 @@ E.g. how you *know* a vehicle has *definitely been* withdrawn or repainted,
 link to a picture to prove it. Be polite.""",
     )
     rules = forms.BooleanField(
-        label="I agree that my edit is made in good faith and complies with the "<a href="/rules">editing rules</a>,
+        label="I agree that my edit is made in good faith and complies with the <a href=\"/rules\ ">editing rules</a>",
         required=true,
     )
 

--- a/vehicles/forms.py
+++ b/vehicles/forms.py
@@ -48,6 +48,7 @@ class EditVehicleForm(forms.Form):
         "previous_reg",
         "features",
         "notes",
+        "rules",
     ]
     spare_ticket_machine = forms.BooleanField(
         required=False,
@@ -121,6 +122,10 @@ class EditVehicleForm(forms.Form):
 if they need explaining.
 E.g. how you *know* a vehicle has *definitely been* withdrawn or repainted,
 link to a picture to prove it. Be polite.""",
+    )
+    rules = forms.BooleanField(
+        label="I agree that my edit is made in good faith and complies with the "<a href="/rules">editing rules</a>"
+        required=true,
     )
 
     def clean_reg(self):


### PR DESCRIPTION
This checkbox will make the rules more prominent as since the rules have come off the edit page, we have more people making edits who aren't aware of the rules. Also issues where people aren't understanding why edits are declined so hopefully this will make it clearer for people what is expected of them.