### PR TITLE
Spare machines don't need operator changing

### DIFF
--- a/vehicles/forms.py
+++ b/vehicles/forms.py
@@ -182,6 +182,7 @@ link to a picture to prove it. Be polite.""",
 
         if vehicle.is_spare_ticket_machine():
             del self.fields["notes"]
+            del self.fields["operator"]
             if not vehicle.fleet_code:
                 del self.fields["fleet_number"]
             if not vehicle.reg:


### PR DESCRIPTION
Updating vehicle edit form to stop people moving 'spare ticket machines' to another op

Rare, if ever that spares need to move between ops. Just removing to stop people getting tempted.