### PR TITLE
TFLO TMP machines default withdraw

### DIFF
--- a/vehicles/management/commands/import_bod_avl.py
+++ b/vehicles/management/commands/import_bod_avl.py
@@ -154,6 +154,7 @@ class Command(ImportLiveVehiclesCommand):
             if vehicle_ref.startswith("TMP"):
                 defaults["notes"] = "Spare ticket machine"
                 defaults["locked"] = True
+                defaults["withdrawn"] True
             vehicles = self.vehicles.filter(
                 Q(operator__in=operators) | Q(operator=None)
             )

--- a/vehicles/management/commands/import_bod_avl.py
+++ b/vehicles/management/commands/import_bod_avl.py
@@ -154,7 +154,7 @@ class Command(ImportLiveVehiclesCommand):
             if vehicle_ref.startswith("TMP"):
                 defaults["notes"] = "Spare ticket machine"
                 defaults["locked"] = True
-                defaults["withdrawn"] True
+                defaults["withdrawn"] = True
             vehicles = self.vehicles.filter(
                 Q(operator__in=operators) | Q(operator=None)
             )


### PR DESCRIPTION
As TMP machines now link to the TFLO operator code and they are locked, it means they are forever visible as no one can withdraw them. 

This commit withdraws them by default as no one needs to edit them (bar withdraw) and no one needs to be able to see them on a list.