### PR TITLE
always show livery name if no branding

### DIFF
--- a/vehicles/models.py
+++ b/vehicles/models.py
@@ -117,7 +117,7 @@ class VehicleType(models.Model):
 
 class Livery(models.Model):
     name = models.CharField(max_length=255, db_index=True)
-    show_name = models.BooleanField(default=True)
+    show_name = models.BooleanField(default=True, help_text="If branding is present, show livery name?")
     colour = ColourField(
         max_length=7, help_text="For the most simplified version of the livery"
     )

--- a/vehicles/templates/operator_vehicles.html
+++ b/vehicles/templates/operator_vehicles.html
@@ -107,11 +107,11 @@ ticket machines, a byproduct of the live bus tracking.</p>
                         {{ vehicle.last_seen.when|date:"j M Y" }}
                     {% endif %}
                 </td>{% endif %}
-                <td{% if vehicle.colours or vehicle.livery_id %} class="livery-cell"{% endif %}{% if branding_column %}{% if not vehicle.branding or not vehicle.livery_name %} colspan="2"{% endif %}{% endif %}>
+                <td{% if vehicle.colours or vehicle.livery_id %} class="livery-cell" {% endif %}{% if branding_column %}{% if not vehicle.branding or not vehicle.show_livery_name %} colspan="2"{% endif %}{% endif %}>
                     {% if vehicle.colours or vehicle.livery_id %}<div class="livery{% if vehicle.livery_id %} livery-{{ vehicle.livery_id }}{% else %}" style="background:{{ vehicle.get_livery }}{% endif %}"></div>{% endif %}
-                    {% if vehicle.livery_name %}{{ vehicle.livery_name }}{% else %}{{ vehicle.branding }}{% endif %}
+                    {% if vehicle.livery_name and vehicle.show_livery_name or vehicle.livery_name and not vehicle.branding %}{{ vehicle.livery_name }}{% else %}{{ vehicle.branding }}{% endif %}
                 </td>
-                {% if vehicle.branding and vehicle.livery_name %}<td>{{ vehicle.branding }}</td>{% endif %}
+                {% if vehicle.branding and vehicle.show_livery_name %}<td>{{ vehicle.branding }}</td>{% endif %}
                 <td>{% if vehicle.is_spare_ticket_machine %}{{ vehicle.notes }}{% else %}{{ vehicle.vehicle_type_name|default:"" }}{% endif %}</td>
                 {% if name_column %}<td class="trivia">{{ vehicle.name }}</td>{% endif %}
                 {% if notes_column %}<td class="trivia">{% if not vehicle.is_spare_ticket_machine %}{{ vehicle.notes }}{% endif %}</td>{% endif %}

--- a/vehicles/templates/vehicle_info.html
+++ b/vehicles/templates/vehicle_info.html
@@ -12,7 +12,7 @@
         {% endif %}
         <div class="livery" style="background:{{ vehicle.get_livery }}"></div>
         {% if vehicle.livery and perms.vehicles.change_livery %}</a>{% endif %}
-        {% if vehicle.livery.show_name %}{{ vehicle.livery.name }}{% endif %}
+        {% if vehicle.livery.show_name or not vehicle.branding %}{{ vehicle.livery.name }}{% endif %}
             </dd>
         </div>
     {% endif %}

--- a/vehicles/views.py
+++ b/vehicles/views.py
@@ -193,7 +193,8 @@ def operator_vehicles(request, slug=None, parent=None):
         context = {"object": operator, "breadcrumb": [operator.region, operator]}
 
     vehicles = vehicles.annotate(
-        livery_name=Case(When(livery__show_name=True, then="livery__name")),
+        livery_name=F("livery__name"),
+        show_livery_name=F("livery__show_name"),
         vehicle_type_name=F("vehicle_type__name"),
         garage_name=Case(
             When(garage__name="", then="garage__code"),


### PR DESCRIPTION
This change will make it so that if show_name is unticked, the livery name will only be hidden if there is branding present on the vehicle. If there is no branding, the livery name will still be shown.