### PR TITLE
added dropdown to bus operator

### DIFF
--- a/accounts/templates/register.html
+++ b/accounts/templates/register.html
@@ -15,11 +15,12 @@
 
     {% load email_obfuscator %}
 
-    <p><strong>If you’re a bus operator or transport authority</strong>,
-    although updating the information about your vehicles on this website may not be a high priority,
-    you’re welcome to request an account by emailing
-    {{ 'hallo@bustimes.org?subject=Invitation request&body=[Delete this text. Briefly explain who you are]'|obfuscate_mailto:'hallo@bustimes.org' }}
-    <strong>from an official-looking email address, explaining who you are</strong>.</p>
+    <details>
+        <summary><strong>Are you a bus operator or transport authority?</strong></summary>
+        <p>Although updating the information about your vehicles on this website may not be a high priority, you're welcome to request an account by emailing
+       {{ 'hallo@bustimes.org?subject=Invitation request&body=&#91;Delete this text. Briefly explain who you are&#93;'|obfuscate_mailto:'hallo@bustimes.org' }}
+        <strong>from an official-looking email address, explaining who you are</strong>.</p>
+    </details>
 
     <p>If not, you can still enjoy all the main features of bustimes.org without an account.
     You can also suggest edits (in line with <a href="/rules">the rules</a>) <a href="/contact">by email</a> or <a href="https://discord.com/invite/gY4PdDFau7">on Discord</a>.</p>


### PR DESCRIPTION
Replaced static text with a dropdown for bus operators, should hopefully reduce the amount of empty emails

As per: https://github.com/bustimes/bustimes.org/commit/3f5ba84f801bd1da177b7d867c639e2c00aa7248#commitcomment-183238915